### PR TITLE
Mount the repo root instead of the webroot

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,7 +56,7 @@ vconfig['sites'].each do |webroot, sites|
     # Append a synced folder for this site to the config's list of existing
     # synced folders.
     vconfig['vagrant_synced_folders'] << {
-      'local_path'  => vconfig['sites_path'] + '/' + site + webroot,
+      'local_path'  => vconfig['sites_path'] + '/' + site,
       'destination' => guest_path,
       'type'        => 'nfs',
       'create'      => 'true',
@@ -79,13 +79,13 @@ vconfig['sites'].each do |webroot, sites|
       when 'apache'
         vconfig['apache_vhosts'] << {
           'servername'       => "#{host}.{{ vagrant_hostname }}",
-          'documentroot'     => guest_path,
-          'extra_parameters' => "ProxyPassMatch ^/(.*\.php(/.*)?)$ \"fcgi://127.0.0.1:9000#{guest_path}\""
+          'documentroot'     => guest_path + webroot,
+          'extra_parameters' => "ProxyPassMatch ^/(.*\.php(/.*)?)$ \"fcgi://127.0.0.1:9000#{guest_path + webroot}\""
         }
       when 'nginx'
         vconfig['nginx_hosts'] << {
           'server_name' => "#{host}.{{ vagrant_hostname }}",
-          'root'        => guest_path,
+          'root'        => guest_path + webroot,
           'is_php'      => 'true',
         }
       else

--- a/provisioning/tasks/ucsf-multisite.yml
+++ b/provisioning/tasks/ucsf-multisite.yml
@@ -2,7 +2,7 @@
 # Create the local "sites.php" file for the UCSF multisite.
 
 - name: See if the UCSF repo exists.
-  shell: "test -d /var/www/ucsf/sites"
+  shell: "test -d /var/www/ucsf/docroot/sites"
   register: ucsf_exists
   ignore_errors: yes
 
@@ -10,5 +10,5 @@
   when: ucsf_exists.rc == 0
   template:
     src: ../templates/ucsf--local.sites.inc.j2
-    dest: /var/www/ucsf/sites/local.sites.inc
+    dest: /var/www/ucsf/docroot/sites/local.sites.inc
     mode: 0644


### PR DESCRIPTION
This is needed especially for Drupal 8 sites where the autoload.php
might live above the webroot.